### PR TITLE
Rate limiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
+
 ## dynamic_bonding_curve [0.1.1] [PR #71](https://github.com/MeteoraAg/dynamic-bonding-curve/pull/71)
 
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The Dynamic Bonding Curve program is a launch pool protocol that allows any laun
 
 - multiple quote tokens support: SOL, USDC, etc
 - SPL Token and Token2022 support
-- fee scheduler + dynamic-fee
+- fee scheduler/rate limiter + dynamic-fee
 - flexible fee collect mode (ex: collect fee only in quote token)
 - customizable liquidity distribution (up to 20 price ranges with different liquidity curve)
 
@@ -29,10 +29,10 @@ The Dynamic Bonding Curve program is a launch pool protocol that allows any laun
 
 Partner can specify these parameters when they create a configuration on all their pools:
 
-- `pool_fees`: include `base_fee` and `dynamic_fee` (optional). Partner can add fee scheduler in `base_fee` or just a fixed fee. `pool_fees` defines the trading fee for any pool that is created from this configuration.
+- `pool_fees`: include `base_fee` and `dynamic_fee` (optional). Partner can add fee scheduler or rate limiter in `base_fee` or just a fixed fee. `pool_fees` defines the trading fee for any pool that is created from this configuration.
 - `collect_fee_mode` (`0 | 1`): `0` means the virtual pool will only collect fee in quote token, `1` means virtual pool will collect fee in both tokens.
 - `migration_option`: right now we only support migration to Meteora DAMM, so partner must set the value as `0` for this field.
-- `activation_type` (`0 | 1`): `0` means slot, `1` means timestamp, this field indicates the time unit that pool will work with, mostly in calculating fee scheduler and dynamic fee.
+- `activation_type` (`0 | 1`): `0` means slot, `1` means timestamp, this field indicates the time unit that pool will work with, mostly in calculating fee scheduler/ rate limiter and dynamic fee.
 - `token_type` (`0 | 1`): `0` means SPL Token, `1` means Token2022.
 - `token_decimal`: the token decimals that the token will use when user creates the virtual pool with this configuration, we only support token decimals from 6 to 9.
 - `partner_lp_percentage`: the percentage of LP that partner can claim after token is migrated.

--- a/programs/dynamic-bonding-curve/src/base_fee/fee_rate_limiter.rs
+++ b/programs/dynamic-bonding-curve/src/base_fee/fee_rate_limiter.rs
@@ -1,0 +1,103 @@
+use crate::{
+    constants::fee::{FEE_DENOMINATOR, MAX_FEE_NUMERATOR},
+    params::{fee_parameters::to_numerator, swap::TradeDirection},
+    safe_math::SafeMath,
+    state::CollectFeeMode,
+    u128x128_math::Rounding,
+    utils_math::safe_mul_div_cast_u64,
+    PoolError,
+};
+
+use super::BaseFeeHandler;
+use anchor_lang::prelude::*;
+use num::Integer;
+
+#[derive(Debug, Default)]
+pub struct FeeRateLimiter {
+    pub cliff_fee_numerator: u64,
+    pub reference_amount: u64,
+    pub max_limiter_duration: u64,
+    pub fee_increment_bps: u16,
+}
+
+impl FeeRateLimiter {
+    fn is_zero_rate_limiter(&self) -> bool {
+        self.reference_amount == 0 && self.max_limiter_duration == 0 && self.fee_increment_bps == 0
+    }
+
+    fn is_non_zero_rate_limiter(&self) -> bool {
+        self.reference_amount != 0 && self.max_limiter_duration != 0 && self.fee_increment_bps != 0
+    }
+
+    fn get_max_index(&self) -> Result<u64> {
+        let delta_numerator = MAX_FEE_NUMERATOR.safe_sub(self.cliff_fee_numerator)?;
+        let fee_increment_numetator =
+            to_numerator(self.fee_increment_bps.into(), FEE_DENOMINATOR.into())?;
+        let max_index = delta_numerator.safe_div(fee_increment_numetator)?;
+        Ok(max_index)
+    }
+
+    fn get_fee_on_amount(&self, input_amount: u64) -> Result<u64> {
+        let (count_index, left_amount) = input_amount.div_rem(&self.reference_amount);
+        let trading_fee: u64 = if count_index == 0 {
+            safe_mul_div_cast_u64(
+                input_amount,
+                self.cliff_fee_numerator,
+                FEE_DENOMINATOR,
+                Rounding::Up,
+            )?
+        } else {
+            let max_index = self.get_max_index()?;
+            if count_index > max_index {
+            } else {
+                // 0 < count index <= max_index
+            }
+        };
+        Ok(0)
+    }
+}
+
+impl BaseFeeHandler for FeeRateLimiter {
+    fn validate(&self, collect_fee_mode: u8) -> Result<()> {
+        let collect_fee_mode = CollectFeeMode::try_from(collect_fee_mode)
+            .map_err(|_| PoolError::InvalidCollectFeeMode)?;
+        // can only be apllied in quote token collect fee mode
+        require!(
+            collect_fee_mode == CollectFeeMode::QuoteToken,
+            PoolError::InvalidFeeRateLimiter
+        );
+
+        if !self.is_zero_rate_limiter() {
+            require!(
+                self.is_non_zero_rate_limiter(),
+                PoolError::InvalidFeeRateLimiter
+            );
+        }
+        // todo add more validation here
+        Ok(())
+    }
+    fn get_base_fee_numerator(
+        &self,
+        current_point: u64,
+        activation_point: u64,
+        trade_direction: TradeDirection,
+        input_amount: u64,
+    ) -> Result<u64> {
+        if self.is_zero_rate_limiter() {
+            return Ok(self.cliff_fee_numerator);
+        }
+
+        // only handle for the case quote to base and collect fee mode in quote token
+        if trade_direction == TradeDirection::BaseToQuote {
+            return Ok(self.cliff_fee_numerator);
+        }
+
+        let last_effective_rate_limiter_point =
+            u128::from(activation_point).safe_add(self.max_limiter_duration.into())?;
+        if u128::from(current_point) > last_effective_rate_limiter_point {
+            return Ok(self.cliff_fee_numerator);
+        }
+
+        self.get_fee_on_amount(input_amount)
+    }
+}

--- a/programs/dynamic-bonding-curve/src/base_fee/fee_scheduler.rs
+++ b/programs/dynamic-bonding-curve/src/base_fee/fee_scheduler.rs
@@ -1,0 +1,101 @@
+use crate::{
+    constants::fee::{FEE_DENOMINATOR, MAX_FEE_NUMERATOR, MIN_FEE_NUMERATOR},
+    fee_math::get_fee_in_period,
+    math::safe_math::SafeMath,
+    params::{fee_parameters::validate_fee_fraction, swap::TradeDirection},
+    PoolError,
+};
+use anchor_lang::prelude::*;
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+
+use super::BaseFeeHandler;
+
+// https://www.desmos.com/calculator/oxdndn2xdx
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq, IntoPrimitive, TryFromPrimitive)]
+pub enum FeeSchedulerMode {
+    // fee = cliff_fee_numerator - passed_period * reduction_factor
+    Linear,
+    // fee = cliff_fee_numerator * (1-reduction_factor/10_000)^passed_period
+    Exponential,
+}
+
+#[derive(Debug, Default)]
+pub struct FeeScheduler {
+    pub cliff_fee_numerator: u64,
+    pub period_frequency: u64,
+    pub reduction_factor: u64,
+    pub number_of_period: u16,
+    pub fee_scheduler_mode: u8,
+}
+
+impl FeeScheduler {
+    pub fn get_max_base_fee_numerator(&self) -> u64 {
+        self.cliff_fee_numerator
+    }
+
+    pub fn get_min_base_fee_numerator(&self) -> Result<u64> {
+        self.get_base_fee_numerator_by_period(self.number_of_period.into())
+    }
+
+    fn get_base_fee_numerator_by_period(&self, period: u64) -> Result<u64> {
+        let period = period.min(self.number_of_period.into());
+
+        let base_fee_mode = FeeSchedulerMode::try_from(self.fee_scheduler_mode)
+            .map_err(|_| PoolError::TypeCastFailed)?;
+
+        match base_fee_mode {
+            FeeSchedulerMode::Linear => {
+                let fee_numerator = self
+                    .cliff_fee_numerator
+                    .safe_sub(self.reduction_factor.safe_mul(period)?)?;
+                Ok(fee_numerator)
+            }
+            FeeSchedulerMode::Exponential => {
+                let period = u16::try_from(period).map_err(|_| PoolError::MathOverflow)?;
+                let fee_numerator =
+                    get_fee_in_period(self.cliff_fee_numerator, self.reduction_factor, period)?;
+                Ok(fee_numerator)
+            }
+        }
+    }
+}
+
+impl BaseFeeHandler for FeeScheduler {
+    fn validate(&self, _collect_fee_mode: u8) -> Result<()> {
+        if self.period_frequency != 0 || self.number_of_period != 0 || self.reduction_factor != 0 {
+            require!(
+                self.number_of_period != 0
+                    && self.period_frequency != 0
+                    && self.reduction_factor != 0,
+                PoolError::InvalidFeeScheduler
+            );
+        }
+        let min_fee_numerator = self.get_min_base_fee_numerator()?;
+        let max_fee_numerator = self.get_max_base_fee_numerator();
+        validate_fee_fraction(min_fee_numerator, FEE_DENOMINATOR)?;
+        validate_fee_fraction(max_fee_numerator, FEE_DENOMINATOR)?;
+        require!(
+            min_fee_numerator >= MIN_FEE_NUMERATOR && max_fee_numerator <= MAX_FEE_NUMERATOR,
+            PoolError::ExceedMaxFeeBps
+        );
+        Ok(())
+    }
+    fn get_base_fee_numerator(
+        &self,
+        current_point: u64,
+        activation_point: u64,
+        _trade_direction: TradeDirection,
+        _input_amount: u64,
+    ) -> Result<u64> {
+        if self.period_frequency == 0 {
+            return Ok(self.cliff_fee_numerator);
+        }
+
+        let period = current_point
+            .safe_sub(activation_point)?
+            .safe_div(self.period_frequency)?;
+
+        self.get_base_fee_numerator_by_period(period)
+    }
+}

--- a/programs/dynamic-bonding-curve/src/base_fee/mod.rs
+++ b/programs/dynamic-bonding-curve/src/base_fee/mod.rs
@@ -1,0 +1,51 @@
+pub mod fee_scheduler;
+pub use fee_scheduler::*;
+pub mod fee_rate_limiter;
+pub use fee_rate_limiter::*;
+
+use anchor_lang::prelude::*;
+
+use crate::{params::swap::TradeDirection, state::BaseFeeMode, PoolError};
+
+pub trait BaseFeeHandler {
+    fn validate(&self, collect_fee_mode: u8) -> Result<()>;
+    fn get_base_fee_numerator(
+        &self,
+        current_point: u64,
+        activation_point: u64,
+        trade_direction: TradeDirection,
+        input_amount: u64,
+    ) -> Result<u64>;
+}
+
+pub fn get_base_fee_handler(
+    cliff_fee_numerator: u64,
+    first_factor: u16,
+    second_factor: u64,
+    third_factor: u64,
+    base_fee_mode: u8,
+) -> Result<Box<dyn BaseFeeHandler>> {
+    let base_fee_mode =
+        BaseFeeMode::try_from(base_fee_mode).map_err(|_| PoolError::InvalidBaseFeeMode)?;
+    match base_fee_mode {
+        BaseFeeMode::FeeSchedulerLinear | BaseFeeMode::FeeSchedulerExponential => {
+            let fee_scheduler = FeeScheduler {
+                cliff_fee_numerator: cliff_fee_numerator,
+                period_frequency: third_factor,
+                reduction_factor: second_factor,
+                number_of_period: first_factor,
+                fee_scheduler_mode: base_fee_mode.into(),
+            };
+            Ok(Box::new(fee_scheduler))
+        }
+        BaseFeeMode::RateLimiter => {
+            let fee_rate_limiter = FeeRateLimiter {
+                cliff_fee_numerator: cliff_fee_numerator,
+                reference_amount: third_factor,
+                max_limiter_duration: second_factor,
+                fee_increment_bps: first_factor,
+            };
+            Ok(Box::new(fee_rate_limiter))
+        }
+    }
+}

--- a/programs/dynamic-bonding-curve/src/constants.rs
+++ b/programs/dynamic-bonding-curve/src/constants.rs
@@ -35,8 +35,8 @@ pub mod fee {
     pub const FEE_DENOMINATOR: u64 = 1_000_000_000;
 
     /// Max fee BPS
-    pub const MAX_FEE_BPS: u64 = 5000; // 50%
-    pub const MAX_FEE_NUMERATOR: u64 = 500_000_000; // 50%
+    pub const MAX_FEE_BPS: u64 = 9900; // 99%
+    pub const MAX_FEE_NUMERATOR: u64 = 990_000_000; // 99%
 
     /// Max basis point. 100% in pct
     pub const MAX_BASIS_POINT: u64 = 10000;

--- a/programs/dynamic-bonding-curve/src/error.rs
+++ b/programs/dynamic-bonding-curve/src/error.rs
@@ -112,4 +112,10 @@ pub enum PoolError {
 
     #[msg("Invalid creator trading fee percentage")]
     InvalidCreatorTradingFeePercentage,
+
+    #[msg("Invalid base fee mode")]
+    InvalidBaseFeeMode,
+
+    #[msg("Invalid fee rate limiter")]
+    InvalidFeeRateLimiter,
 }

--- a/programs/dynamic-bonding-curve/src/instructions/partner/ix_create_config.rs
+++ b/programs/dynamic-bonding-curve/src/instructions/partner/ix_create_config.rs
@@ -124,7 +124,7 @@ impl ConfigParameters {
         );
 
         // validate fee
-        self.pool_fees.validate()?;
+        self.pool_fees.validate(self.collect_fee_mode)?;
 
         // validate creator trading fee percentage
         require!(

--- a/programs/dynamic-bonding-curve/src/lib.rs
+++ b/programs/dynamic-bonding-curve/src/lib.rs
@@ -18,6 +18,7 @@ pub mod utils;
 pub use utils::*;
 pub mod math;
 pub use math::*;
+pub mod base_fee;
 pub mod curve;
 pub mod tests;
 

--- a/programs/dynamic-bonding-curve/src/params/fee_parameters.rs
+++ b/programs/dynamic-bonding-curve/src/params/fee_parameters.rs
@@ -1,8 +1,6 @@
 //! Fees module includes information about fee charges
-use crate::constants::fee::{
-    FEE_DENOMINATOR, HOST_FEE_PERCENT, MAX_BASIS_POINT, MAX_FEE_NUMERATOR, MIN_FEE_NUMERATOR,
-    PROTOCOL_FEE_PERCENT,
-};
+use crate::base_fee::get_base_fee_handler;
+use crate::constants::fee::{HOST_FEE_PERCENT, MAX_BASIS_POINT, PROTOCOL_FEE_PERCENT};
 use crate::constants::{BASIS_POINT_MAX, BIN_STEP_BPS_DEFAULT, BIN_STEP_BPS_U128_DEFAULT, U24_MAX};
 use crate::error::PoolError;
 use crate::safe_math::SafeMath;
@@ -21,63 +19,32 @@ pub struct PoolFeeParameters {
 #[derive(Copy, Clone, Debug, AnchorSerialize, AnchorDeserialize, InitSpace, Default)]
 pub struct BaseFeeParameters {
     pub cliff_fee_numerator: u64,
-    pub number_of_period: u16,
-    pub period_frequency: u64,
-    pub reduction_factor: u64,
-    pub fee_scheduler_mode: u8,
-}
-
-#[derive(Default, PartialEq)]
-struct FeeSchedulerParameters {
-    pub number_of_period: u16,
-    pub period_frequency: u64,
-    pub reduction_factor: u64,
-}
-
-impl FeeSchedulerParameters {
-    fn validate_non_zero(&self) -> Result<()> {
-        require!(
-            self.number_of_period != 0 && self.period_frequency != 0 && self.reduction_factor != 0,
-            PoolError::InvalidFeeScheduler
-        );
-        Ok(())
-    }
+    pub first_factor: u16,
+    pub second_factor: u64,
+    pub third_factor: u64,
+    pub base_fee_mode: u8,
 }
 
 impl BaseFeeParameters {
-    fn validate(&self) -> Result<()> {
-        let base_fee_scheduler = self.to_base_fee_scheduler();
-        if base_fee_scheduler != FeeSchedulerParameters::default() {
-            base_fee_scheduler.validate_non_zero()?;
-        }
-        let base_fee_config = self.to_base_fee_config();
-
-        let min_fee_numerator = base_fee_config.get_min_base_fee_numerator()?;
-        let max_fee_numerator = base_fee_config.get_max_base_fee_numerator();
-        validate_fee_fraction(min_fee_numerator, FEE_DENOMINATOR)?;
-        validate_fee_fraction(max_fee_numerator, FEE_DENOMINATOR)?;
-        require!(
-            min_fee_numerator >= MIN_FEE_NUMERATOR && max_fee_numerator <= MAX_FEE_NUMERATOR,
-            PoolError::ExceedMaxFeeBps
-        );
+    fn validate(&self, collect_fee_mode: u8) -> Result<()> {
+        let base_fee_handler = get_base_fee_handler(
+            self.cliff_fee_numerator,
+            self.first_factor,
+            self.second_factor,
+            self.third_factor,
+            self.base_fee_mode,
+        )?;
+        base_fee_handler.validate(collect_fee_mode)?;
         Ok(())
-    }
-
-    fn to_base_fee_scheduler(&self) -> FeeSchedulerParameters {
-        FeeSchedulerParameters {
-            number_of_period: self.number_of_period,
-            period_frequency: self.period_frequency,
-            reduction_factor: self.reduction_factor,
-        }
     }
 
     pub fn to_base_fee_config(&self) -> BaseFeeConfig {
         BaseFeeConfig {
             cliff_fee_numerator: self.cliff_fee_numerator,
-            number_of_period: self.number_of_period,
-            period_frequency: self.period_frequency,
-            reduction_factor: self.reduction_factor,
-            fee_scheduler_mode: self.fee_scheduler_mode,
+            first_factor: self.first_factor,
+            second_factor: self.second_factor,
+            third_factor: self.third_factor,
+            base_fee_mode: self.base_fee_mode,
             ..Default::default()
         }
     }
@@ -207,10 +174,17 @@ pub fn to_bps(numerator: u128, denominator: u128) -> Result<u64> {
     Ok(u64::try_from(bps).map_err(|_| PoolError::TypeCastFailed)?)
 }
 
+pub fn to_numerator(bps: u128, denominator: u128) -> Result<u64> {
+    let numerator = bps
+        .safe_mul(denominator.into())?
+        .safe_div(MAX_BASIS_POINT.into())?;
+    Ok(u64::try_from(numerator).map_err(|_| PoolError::TypeCastFailed)?)
+}
+
 impl PoolFeeParameters {
     /// Validate that the fees are reasonable
-    pub fn validate(&self) -> Result<()> {
-        self.base_fee.validate()?;
+    pub fn validate(&self, collect_fee_mode: u8) -> Result<()> {
+        self.base_fee.validate(collect_fee_mode)?;
 
         if let Some(dynamic_fee) = self.dynamic_fee {
             dynamic_fee.validate()?;

--- a/programs/dynamic-bonding-curve/src/state/config.rs
+++ b/programs/dynamic-bonding-curve/src/state/config.rs
@@ -4,14 +4,15 @@ use ruint::aliases::U256;
 use static_assertions::const_assert_eq;
 
 use crate::{
+    base_fee::get_base_fee_handler,
     constants::{
         fee::{FEE_DENOMINATOR, MAX_FEE_NUMERATOR},
         MAX_CURVE_POINT_CONFIG, MAX_SQRT_PRICE, MAX_SWALLOW_PERCENTAGE, SWAP_BUFFER_PERCENTAGE,
     },
-    fee_math::get_fee_in_period,
     params::{
         fee_parameters::PoolFeeParameters,
         liquidity_distribution::{get_base_token_for_swap, LiquidityDistributionParameters},
+        swap::TradeDirection,
     },
     safe_math::SafeMath,
     u128x128_math::Rounding,
@@ -34,11 +35,13 @@ use super::fee::{FeeOnAmountResult, VolatilityTracker};
     AnchorSerialize,
 )]
 // https://www.desmos.com/calculator/oxdndn2xdx
-pub enum FeeSchedulerMode {
+pub enum BaseFeeMode {
     // fee = cliff_fee_numerator - passed_period * reduction_factor
-    Linear,
+    FeeSchedulerLinear,
     // fee = cliff_fee_numerator * (1-reduction_factor/10_000)^passed_period
-    Exponential,
+    FeeSchedulerExponential,
+    // TODO
+    RateLimiter,
 }
 
 #[zero_copy]
@@ -66,10 +69,15 @@ impl PoolFeesConfig {
         volatility_tracker: &VolatilityTracker,
         current_point: u64,
         activation_point: u64,
+        amount: u64,
+        trade_direction: TradeDirection,
     ) -> Result<u64> {
-        let base_fee_numerator = self
-            .base_fee
-            .get_base_fee_numerator(current_point, activation_point)?;
+        let base_fee_numerator = self.base_fee.get_base_fee_numerator(
+            current_point,
+            activation_point,
+            amount,
+            trade_direction,
+        )?;
 
         let total_fee_numerator = self
             .dynamic_fee
@@ -89,13 +97,19 @@ impl PoolFeesConfig {
     pub fn get_fee_on_amount(
         &self,
         volatility_tracker: &VolatilityTracker,
-        amount: u64,
         has_referral: bool,
+        amount: u64,
         current_point: u64,
         activation_point: u64,
+        trade_direction: TradeDirection,
     ) -> Result<FeeOnAmountResult> {
-        let trade_fee_numerator =
-            self.get_total_trading_fee(volatility_tracker, current_point, activation_point)?;
+        let trade_fee_numerator = self.get_total_trading_fee(
+            volatility_tracker,
+            current_point,
+            activation_point,
+            amount,
+            trade_direction,
+        )?;
 
         let trading_fee: u64 =
             safe_mul_div_cast_u64(amount, trade_fee_numerator, FEE_DENOMINATOR, Rounding::Up)?;
@@ -138,56 +152,36 @@ impl PoolFeesConfig {
 #[derive(Debug, InitSpace, Default)]
 pub struct BaseFeeConfig {
     pub cliff_fee_numerator: u64,
-    pub period_frequency: u64,
-    pub reduction_factor: u64,
-    pub number_of_period: u16,
-    pub fee_scheduler_mode: u8,
+    pub third_factor: u64,
+    pub second_factor: u64,
+    pub first_factor: u16,
+    pub base_fee_mode: u8,
     pub padding_0: [u8; 5],
 }
 
 const_assert_eq!(BaseFeeConfig::INIT_SPACE, 32);
 
 impl BaseFeeConfig {
-    pub fn get_max_base_fee_numerator(&self) -> u64 {
-        self.cliff_fee_numerator
-    }
-
-    pub fn get_min_base_fee_numerator(&self) -> Result<u64> {
-        self.get_base_fee_numerator_by_period(self.number_of_period.into())
-    }
-
-    pub fn get_base_fee_numerator(&self, current_point: u64, activation_point: u64) -> Result<u64> {
-        if self.period_frequency == 0 {
-            return Ok(self.cliff_fee_numerator);
-        }
-
-        let period = current_point
-            .safe_sub(activation_point)?
-            .safe_div(self.period_frequency)?;
-
-        self.get_base_fee_numerator_by_period(period)
-    }
-
-    fn get_base_fee_numerator_by_period(&self, period: u64) -> Result<u64> {
-        let period = period.min(self.number_of_period.into());
-
-        let fee_scheduler_mode = FeeSchedulerMode::try_from(self.fee_scheduler_mode)
-            .map_err(|_| PoolError::TypeCastFailed)?;
-
-        match fee_scheduler_mode {
-            FeeSchedulerMode::Linear => {
-                let fee_numerator = self
-                    .cliff_fee_numerator
-                    .safe_sub(self.reduction_factor.safe_mul(period)?)?;
-                Ok(fee_numerator)
-            }
-            FeeSchedulerMode::Exponential => {
-                let period = u16::try_from(period).map_err(|_| PoolError::MathOverflow)?;
-                let fee_numerator =
-                    get_fee_in_period(self.cliff_fee_numerator, self.reduction_factor, period)?;
-                Ok(fee_numerator)
-            }
-        }
+    pub fn get_base_fee_numerator(
+        &self,
+        current_point: u64,
+        activation_point: u64,
+        amount: u64,
+        trade_direction: TradeDirection,
+    ) -> Result<u64> {
+        let base_fee_handler = get_base_fee_handler(
+            self.cliff_fee_numerator,
+            self.first_factor,
+            self.second_factor,
+            self.third_factor,
+            self.base_fee_mode,
+        )?;
+        base_fee_handler.get_base_fee_numerator(
+            current_point,
+            activation_point,
+            trade_direction,
+            amount,
+        )
     }
 }
 

--- a/programs/dynamic-bonding-curve/src/state/config.rs
+++ b/programs/dynamic-bonding-curve/src/state/config.rs
@@ -594,11 +594,24 @@ impl PoolConfig {
     }
 
     pub fn get_liquidity_distribution(&self, liquidity: u128) -> Result<LiquidityDistribution> {
-        let partner_locked_lp =
-            safe_mul_div_cast_u128(liquidity, self.partner_locked_lp_percentage.into(), 100)?;
-        let partner_lp = safe_mul_div_cast_u128(liquidity, self.partner_lp_percentage.into(), 100)?;
-        let creator_locked_lp =
-            safe_mul_div_cast_u128(liquidity, self.creator_locked_lp_percentage.into(), 100)?;
+        let partner_locked_lp = safe_mul_div_cast_u128(
+            liquidity,
+            self.partner_locked_lp_percentage.into(),
+            100,
+            Rounding::Down,
+        )?;
+        let partner_lp = safe_mul_div_cast_u128(
+            liquidity,
+            self.partner_lp_percentage.into(),
+            100,
+            Rounding::Down,
+        )?;
+        let creator_locked_lp = safe_mul_div_cast_u128(
+            liquidity,
+            self.creator_locked_lp_percentage.into(),
+            100,
+            Rounding::Down,
+        )?;
 
         let creator_lp = liquidity
             .safe_sub(partner_locked_lp)?

--- a/programs/dynamic-bonding-curve/src/state/virtual_pool.rs
+++ b/programs/dynamic-bonding-curve/src/state/virtual_pool.rs
@@ -219,10 +219,11 @@ impl VirtualPool {
                 referral_fee,
             } = config.pool_fees.get_fee_on_amount(
                 &self.volatility_tracker,
-                amount_in,
                 fee_mode.has_referral,
+                amount_in,
                 current_point,
                 self.activation_point,
+                trade_direction,
             )?;
 
             actual_protocol_fee = protocol_fee;
@@ -256,10 +257,11 @@ impl VirtualPool {
                 referral_fee,
             } = config.pool_fees.get_fee_on_amount(
                 &self.volatility_tracker,
-                output_amount,
                 fee_mode.has_referral,
+                output_amount,
                 current_point,
                 self.activation_point,
+                trade_direction,
             )?;
 
             actual_protocol_fee = protocol_fee;

--- a/programs/dynamic-bonding-curve/src/tests/mod.rs
+++ b/programs/dynamic-bonding-curve/src/tests/mod.rs
@@ -12,3 +12,6 @@ mod test_volitility_accumulate;
 
 #[cfg(test)]
 mod test_total_supply;
+
+#[cfg(test)]
+mod test_rate_limiter;

--- a/programs/dynamic-bonding-curve/src/tests/test_rate_limiter.rs
+++ b/programs/dynamic-bonding-curve/src/tests/test_rate_limiter.rs
@@ -1,0 +1,222 @@
+use crate::{
+    base_fee::{BaseFeeHandler, FeeRateLimiter},
+    constants::fee::{FEE_DENOMINATOR, MAX_FEE_NUMERATOR, MIN_FEE_NUMERATOR},
+    params::{
+        fee_parameters::{to_bps, to_numerator},
+        swap::TradeDirection,
+    },
+    u128x128_math::Rounding,
+    utils_math::safe_mul_div_cast_u64,
+};
+
+#[test]
+fn test_validate_rate_limiter() {
+    // validate collect fee mode
+    {
+        let rate_limiter = FeeRateLimiter {
+            cliff_fee_numerator: 10_0000,
+            reference_amount: 1_000_000_000, // 1SOL
+            max_limiter_duration: 60,        // 60 seconds
+            fee_increment_bps: 10,           // 10 bps
+        };
+        assert!(rate_limiter.validate(1).is_err());
+        assert!(rate_limiter.validate(0).is_ok());
+    }
+
+    // validate zero rate limiter
+    {
+        let rate_limiter = FeeRateLimiter {
+            cliff_fee_numerator: 10_0000,
+            reference_amount: 1,     // 1SOL
+            max_limiter_duration: 0, // 60 seconds
+            fee_increment_bps: 0,    // 10 bps
+        };
+        assert!(rate_limiter.validate(0).is_err());
+        let rate_limiter = FeeRateLimiter {
+            cliff_fee_numerator: 10_0000,
+            reference_amount: 0,     // 1SOL
+            max_limiter_duration: 1, // 60 seconds
+            fee_increment_bps: 0,    // 10 bps
+        };
+        assert!(rate_limiter.validate(0).is_err());
+        let rate_limiter = FeeRateLimiter {
+            cliff_fee_numerator: 10_0000,
+            reference_amount: 0,     // 1SOL
+            max_limiter_duration: 0, // 60 seconds
+            fee_increment_bps: 1,    // 10 bps
+        };
+        assert!(rate_limiter.validate(0).is_err());
+    }
+
+    // validate cliff fee numerator
+    {
+        let rate_limiter = FeeRateLimiter {
+            cliff_fee_numerator: MIN_FEE_NUMERATOR - 1,
+            reference_amount: 1_000_000_000, // 1SOL
+            max_limiter_duration: 60,        // 60 seconds
+            fee_increment_bps: 10,           // 10 bps
+        };
+        assert!(rate_limiter.validate(0).is_err());
+        let rate_limiter = FeeRateLimiter {
+            cliff_fee_numerator: MAX_FEE_NUMERATOR + 1,
+            reference_amount: 1_000_000_000, // 1SOL
+            max_limiter_duration: 60,        // 60 seconds
+            fee_increment_bps: 10,           // 10 bps
+        };
+        assert!(rate_limiter.validate(0).is_err());
+    }
+}
+
+// that test show that more amount, then more fee numerator
+#[test]
+fn test_rate_limiter_behavior() {
+    let base_fee_bps = 100u64; // 1%
+    let reference_amount = 1_000_000_000; // 1 sol
+    let fee_increment_bps = 100; // 1%
+    let cliff_fee_numerator = to_numerator(base_fee_bps.into(), FEE_DENOMINATOR.into()).unwrap();
+
+    let rate_limiter = FeeRateLimiter {
+        cliff_fee_numerator,
+        reference_amount,         // 1SOL
+        max_limiter_duration: 60, // 60 seconds
+        fee_increment_bps,        // 10 bps
+    };
+    assert!(rate_limiter.validate(0).is_ok());
+
+    {
+        let fee_numerator = rate_limiter
+            .get_fee_numerator_from_amount(reference_amount)
+            .unwrap();
+        let fee_bps = to_bps(fee_numerator.into(), FEE_DENOMINATOR.into()).unwrap();
+        assert_eq!(fee_bps, base_fee_bps);
+    }
+
+    {
+        let fee_numerator = rate_limiter
+            .get_fee_numerator_from_amount(reference_amount * 3 / 2)
+            .unwrap();
+        let fee_bps = to_bps(fee_numerator.into(), FEE_DENOMINATOR.into()).unwrap();
+        assert_eq!(fee_bps, 133);
+
+        let fee_numerator = rate_limiter
+            .get_fee_numerator_from_amount(reference_amount * 2)
+            .unwrap();
+        let fee_bps = to_bps(fee_numerator.into(), FEE_DENOMINATOR.into()).unwrap();
+        assert_eq!(fee_bps, 150); // 1.5%, (1+1+1) / 2
+    }
+
+    {
+        let fee_numerator = rate_limiter
+            .get_fee_numerator_from_amount(reference_amount * 3)
+            .unwrap();
+        let fee_bps = to_bps(fee_numerator.into(), FEE_DENOMINATOR.into()).unwrap();
+        assert_eq!(fee_bps, 200); // 2%, (1+1+1+1) / 2
+    }
+
+    {
+        let fee_numerator = rate_limiter
+            .get_fee_numerator_from_amount(reference_amount * 4)
+            .unwrap();
+        let fee_bps = to_bps(fee_numerator.into(), FEE_DENOMINATOR.into()).unwrap();
+        assert_eq!(fee_bps, 250); // 2.5% (1+1+1+1+1) / 2
+    }
+
+    {
+        let fee_numerator = rate_limiter
+            .get_fee_numerator_from_amount(u64::MAX)
+            .unwrap();
+        let fee_bps = to_bps(fee_numerator.into(), FEE_DENOMINATOR.into()).unwrap();
+        assert_eq!(fee_bps, 9899); // 98.99%
+    }
+}
+
+fn calculate_output_amount(rate_limiter: &FeeRateLimiter, input_amount: u64) -> u64 {
+    let trade_fee_numerator = rate_limiter
+        .get_base_fee_numerator(0, 0, TradeDirection::QuoteToBase, input_amount)
+        .unwrap();
+    let trading_fee: u64 = safe_mul_div_cast_u64(
+        input_amount,
+        trade_fee_numerator,
+        FEE_DENOMINATOR,
+        Rounding::Up,
+    )
+    .unwrap();
+    input_amount.checked_sub(trading_fee).unwrap()
+}
+// that test show that, more input amount, then more output amount
+#[test]
+fn test_rate_limiter_routing_friendly() {
+    let base_fee_bps = 100u64; // 1%
+    let reference_amount = 1_000_000_000; // 1 sol
+    let fee_increment_bps = 100; // 1%
+    let cliff_fee_numerator = to_numerator(base_fee_bps.into(), FEE_DENOMINATOR.into()).unwrap();
+
+    let rate_limiter = FeeRateLimiter {
+        cliff_fee_numerator,
+        reference_amount,         // 1SOL
+        max_limiter_duration: 60, // 60 seconds
+        fee_increment_bps,        // 10 bps
+    };
+
+    let mut input_amount = reference_amount - 10;
+    let mut currrent_output_amount = calculate_output_amount(&rate_limiter, input_amount);
+
+    for _i in 0..500 {
+        input_amount = input_amount + reference_amount / 2;
+        let output_amount = calculate_output_amount(&rate_limiter, input_amount);
+        assert!(output_amount > currrent_output_amount);
+        currrent_output_amount = output_amount
+    }
+}
+
+#[test]
+fn test_rate_limiter_base_fee_numerator() {
+    let base_fee_bps = 100u64; // 1%
+    let reference_amount = 1_000_000_000; // 1 sol
+    let fee_increment_bps = 100; // 1%
+    let cliff_fee_numerator = to_numerator(base_fee_bps.into(), FEE_DENOMINATOR.into()).unwrap();
+
+    let rate_limiter = FeeRateLimiter {
+        cliff_fee_numerator,
+        reference_amount,         // 1SOL
+        max_limiter_duration: 60, // 60 seconds
+        fee_increment_bps,        // 10 bps
+    };
+
+    {
+        // trade from base to quote
+        let fee_numerator = rate_limiter
+            .get_base_fee_numerator(0, 0, TradeDirection::BaseToQuote, 2_000_000_000)
+            .unwrap();
+
+        assert_eq!(fee_numerator, rate_limiter.cliff_fee_numerator);
+    }
+
+    {
+        // trade pass last effective point
+        let fee_numerator = rate_limiter
+            .get_base_fee_numerator(
+                rate_limiter.max_limiter_duration + 1,
+                0,
+                TradeDirection::QuoteToBase,
+                2_000_000_000,
+            )
+            .unwrap();
+
+        assert_eq!(fee_numerator, rate_limiter.cliff_fee_numerator);
+    }
+
+    {
+        // trade in effective point
+        let fee_numerator = rate_limiter
+            .get_base_fee_numerator(
+                rate_limiter.max_limiter_duration,
+                0,
+                TradeDirection::QuoteToBase,
+                2_000_000_000,
+            )
+            .unwrap();
+
+        assert!(fee_numerator > rate_limiter.cliff_fee_numerator);
+    }
+}

--- a/tests/build_graph_curve.tests.ts
+++ b/tests/build_graph_curve.tests.ts
@@ -78,6 +78,13 @@ describe("Build graph curve", () => {
             lockedVesting,
             leftOver,
             kFactor,
+            {
+                cliffFeeNumerator: new BN(2_500_000),
+                firstFactor: 0,
+                secondFactor: new BN(0),
+                thirdFactor: new BN(0),
+                baseFeeMode: 0,
+            }
         );
         const params: CreateConfigParams = {
             payer: partner,
@@ -121,6 +128,13 @@ describe("Build graph curve", () => {
             lockedVesting,
             leftOver,
             kFactor,
+            {
+                cliffFeeNumerator: new BN(2_500_000),
+                firstFactor: 0,
+                secondFactor: new BN(0),
+                thirdFactor: new BN(0),
+                baseFeeMode: 0,
+            }
         );
         const params: CreateConfigParams = {
             payer: partner,

--- a/tests/claim_and_lock_lp_on_meteora_damm.tests.ts
+++ b/tests/claim_and_lock_lp_on_meteora_damm.tests.ts
@@ -55,10 +55,10 @@ async function createPartnerConfig(
 ): Promise<PublicKey> {
   const baseFee: BaseFee = {
     cliffFeeNumerator: new BN(2_500_000),
-    numberOfPeriod: 0,
-    reductionFactor: new BN(0),
-    periodFrequency: new BN(0),
-    feeSchedulerMode: 0,
+    firstFactor: 0,
+    secondFactor: new BN(0),
+    thirdFactor: new BN(0),
+    baseFeeMode: 0,
   };
 
   const curves = [];

--- a/tests/claim_lp_on_meteora_damm.tests.ts
+++ b/tests/claim_lp_on_meteora_damm.tests.ts
@@ -66,10 +66,10 @@ describe("Claim lp on meteora dammm", () => {
     it("Partner create config", async () => {
         const baseFee: BaseFee = {
             cliffFeeNumerator: new BN(2_500_000),
-            numberOfPeriod: 0,
-            reductionFactor: new BN(0),
-            periodFrequency: new BN(0),
-            feeSchedulerMode: 0,
+            firstFactor: 0,
+            secondFactor: new BN(0),
+            thirdFactor: new BN(0),
+            baseFeeMode: 0,
         };
 
         const curves = [];

--- a/tests/create_locker.tests.ts
+++ b/tests/create_locker.tests.ts
@@ -60,10 +60,10 @@ describe("Create locker", () => {
         it("Partner create config", async () => {
             const baseFee: BaseFee = {
                 cliffFeeNumerator: new BN(2_500_000),
-                numberOfPeriod: 0,
-                reductionFactor: new BN(0),
-                periodFrequency: new BN(0),
-                feeSchedulerMode: 0,
+                firstFactor: 0,
+                secondFactor: new BN(0),
+                thirdFactor: new BN(0),
+                baseFeeMode: 0,
             };
 
             const curves = [];
@@ -221,10 +221,10 @@ describe("Create locker", () => {
         it("Partner create config", async () => {
             const baseFee: BaseFee = {
                 cliffFeeNumerator: new BN(2_500_000),
-                numberOfPeriod: 0,
-                reductionFactor: new BN(0),
-                periodFrequency: new BN(0),
-                feeSchedulerMode: 0,
+                firstFactor: 0,
+                secondFactor: new BN(0),
+                thirdFactor: new BN(0),
+                baseFeeMode: 0,
             };
 
             const curves = [];

--- a/tests/create_pool_with_token2022.tests.ts
+++ b/tests/create_pool_with_token2022.tests.ts
@@ -71,10 +71,10 @@ describe("Create pool with token2022", () => {
     it("Partner create config", async () => {
         const baseFee: BaseFee = {
             cliffFeeNumerator: new BN(2_500_000),
-            numberOfPeriod: 0,
-            reductionFactor: new BN(0),
-            periodFrequency: new BN(0),
-            feeSchedulerMode: 0,
+            firstFactor: 0,
+            secondFactor: new BN(0),
+            thirdFactor: new BN(0),
+            baseFeeMode: 0,
         };
 
         const curves = [];

--- a/tests/create_virtual_pool_metadata.tests.ts
+++ b/tests/create_virtual_pool_metadata.tests.ts
@@ -50,10 +50,10 @@ describe("Create virtual pool metadata", () => {
     it("Partner create config", async () => {
         const baseFee: BaseFee = {
             cliffFeeNumerator: new BN(2_500_000),
-            numberOfPeriod: 0,
-            reductionFactor: new BN(0),
-            periodFrequency: new BN(0),
-            feeSchedulerMode: 0,
+            firstFactor: 0,
+            secondFactor: new BN(0),
+            thirdFactor: new BN(0),
+            baseFeeMode: 0,
         };
 
         const curves = [];

--- a/tests/fee_swap.tests.ts
+++ b/tests/fee_swap.tests.ts
@@ -53,10 +53,10 @@ describe("Fee Swap test", () => {
 
       const baseFee: BaseFee = {
         cliffFeeNumerator: new BN(2_500_000),
-        numberOfPeriod: 0,
-        reductionFactor: new BN(0),
-        periodFrequency: new BN(0),
-        feeSchedulerMode: 0,
+        firstFactor: 0,
+        secondFactor: new BN(0),
+        thirdFactor: new BN(0),
+        baseFeeMode: 0,
       };
 
       const curves = [];
@@ -398,10 +398,10 @@ describe("Fee Swap test", () => {
 
       const baseFee: BaseFee = {
         cliffFeeNumerator: new BN(2_500_000),
-        numberOfPeriod: 0,
-        reductionFactor: new BN(0),
-        periodFrequency: new BN(0),
-        feeSchedulerMode: 0,
+        firstFactor: 0,
+        secondFactor: new BN(0),
+        thirdFactor: new BN(0),
+        baseFeeMode: 0,
       };
 
       const curves = [];

--- a/tests/fixed_token_supply.tests.ts
+++ b/tests/fixed_token_supply.tests.ts
@@ -61,10 +61,10 @@ describe("Fixed token supply", () => {
     it("Partner create config", async () => {
         const baseFee: BaseFee = {
             cliffFeeNumerator: new BN(2_500_000),
-            numberOfPeriod: 0,
-            reductionFactor: new BN(0),
-            periodFrequency: new BN(0),
-            feeSchedulerMode: 0,
+            firstFactor: 0,
+            secondFactor: new BN(0),
+            thirdFactor: new BN(0),
+            baseFeeMode: 0,
         };
 
         const curves = [];

--- a/tests/full_flow_with_sol.tests.ts
+++ b/tests/full_flow_with_sol.tests.ts
@@ -82,10 +82,10 @@ describe("Full flow with spl-token", () => {
   it("Partner create config", async () => {
     const baseFee: BaseFee = {
       cliffFeeNumerator: new BN(2_500_000),
-      numberOfPeriod: 0,
-      reductionFactor: new BN(0),
-      periodFrequency: new BN(0),
-      feeSchedulerMode: 0,
+      firstFactor: 0,
+      secondFactor: new BN(0),
+      thirdFactor: new BN(0),
+      baseFeeMode: 0,
     };
 
     const curves = [];

--- a/tests/instructions/adminInstructions.ts
+++ b/tests/instructions/adminInstructions.ts
@@ -32,7 +32,7 @@ export async function createClaimFeeOperator(
   const claimFeeOperator = deriveClaimFeeOperatorAddress(operator);
   const transaction = await program.methods
     .createClaimFeeOperator()
-    .accounts({
+    .accountsPartial({
       claimFeeOperator,
       operator,
       admin: admin.publicKey,
@@ -139,7 +139,7 @@ export async function claimProtocolFee(
 
   const transaction = await program.methods
     .claimProtocolFee()
-    .accounts({
+    .accountsPartial({
       poolAuthority,
       config: poolState.config,
       pool,
@@ -206,7 +206,7 @@ export async function protocolWithdrawSurplus(
 
   const transaction = await program.methods
     .protocolWithdrawSurplus()
-    .accounts({
+    .accountsPartial({
       poolAuthority,
       config: poolState.config,
       virtualPool,

--- a/tests/instructions/meteoraMigration.ts
+++ b/tests/instructions/meteoraMigration.ts
@@ -183,7 +183,7 @@ export async function lockLpForCreatorDamm(
   banksClient: BanksClient,
   program: VirtualCurveProgram,
   params: LockLPDammForCreatorParams
-): Promsie<PublicKey> {
+): Promise<PublicKey> {
   const { payer, virtualPool, dammConfig } = params;
   const virtualPoolState = await getVirtualPool(
     banksClient,

--- a/tests/instructions/partnerInstructions.ts
+++ b/tests/instructions/partnerInstructions.ts
@@ -16,10 +16,10 @@ import { NATIVE_MINT, TOKEN_2022_PROGRAM_ID, TOKEN_PROGRAM_ID } from "@solana/sp
 
 export type BaseFee = {
   cliffFeeNumerator: BN;
-  numberOfPeriod: number;
-  periodFrequency: BN;
-  reductionFactor: BN;
-  feeSchedulerMode: number;
+  firstFactor: number;
+  secondFactor: BN;
+  thirdFactor: BN;
+  baseFeeMode: number;
 };
 
 export type DynamicFee = {

--- a/tests/migrate_to_damm_v2.tests.ts
+++ b/tests/migrate_to_damm_v2.tests.ts
@@ -71,10 +71,10 @@ describe("Migrate to damm v2", () => {
     it("Partner create config", async () => {
         const baseFee: BaseFee = {
             cliffFeeNumerator: new BN(2_500_000),
-            numberOfPeriod: 0,
-            reductionFactor: new BN(0),
-            periodFrequency: new BN(0),
-            feeSchedulerMode: 0,
+            firstFactor: 0,
+            secondFactor: new BN(0),
+            thirdFactor: new BN(0),
+            baseFeeMode: 0,
         };
 
         const curves = [];

--- a/tests/rate_limiter.tests.ts
+++ b/tests/rate_limiter.tests.ts
@@ -1,0 +1,180 @@
+import { ProgramTestContext } from "solana-bankrun";
+import {
+    createConfig,
+    createPoolWithSplToken,
+    swap,
+} from "./instructions";
+import { VirtualCurveProgram } from "./utils/types";
+import { Keypair } from "@solana/web3.js";
+import { designGraphCurve, fundSol, startTest, warpSlotBy } from "./utils";
+import {
+    createVirtualCurveProgram,
+} from "./utils";
+import { getVirtualPool } from "./utils/fetcher";
+
+import { expect } from "chai";
+import { createToken, mintSplTokenTo } from "./utils/token";
+import { BN } from "bn.js";
+
+describe("Rate limiter", () => {
+    let context: ProgramTestContext;
+    let admin: Keypair;
+    let operator: Keypair;
+    let partner: Keypair;
+    let user: Keypair;
+    let poolCreator: Keypair;
+    let program: VirtualCurveProgram;
+
+    before(async () => {
+        context = await startTest();
+        admin = context.payer;
+        operator = Keypair.generate();
+        partner = Keypair.generate();
+        user = Keypair.generate();
+        poolCreator = Keypair.generate();
+        const receivers = [
+            operator.publicKey,
+            partner.publicKey,
+            user.publicKey,
+            poolCreator.publicKey,
+        ];
+        await fundSol(context.banksClient, admin, receivers);
+        program = createVirtualCurveProgram();
+    });
+
+    it("Rate limiter", async () => {
+        let totalTokenSupply = 1_000_000_000; // 1 billion
+        let initialMarketcap = 30; // 30 SOL;
+        let migrationMarketcap = 300; // 300 SOL;        
+        let tokenBaseDecimal = 6;
+        let tokenQuoteDecimal = 9;
+        let kFactor = 1.2;
+        let lockedVesting = {
+            amountPerPeriod: new BN(123456),
+            cliffDurationFromMigrationTime: new BN(0),
+            frequency: new BN(1),
+            numberOfPeriod: new BN(120),
+            cliffUnlockAmount: new BN(123456),
+        };
+        let leftOver = 10_000;
+        let migrationOption = 0;
+        let quoteMint = await createToken(context.banksClient, admin, admin.publicKey, tokenQuoteDecimal);
+        let referenceAmount = new BN(1_000_000_000);
+        let maxRateLimiterDuration = new BN(10);
+        let instructionParams = designGraphCurve(
+            totalTokenSupply,
+            initialMarketcap,
+            migrationMarketcap,
+            migrationOption,
+            tokenBaseDecimal,
+            tokenQuoteDecimal,
+            0,
+            0,
+            lockedVesting,
+            leftOver,
+            kFactor,
+            {
+                cliffFeeNumerator: new BN(10_000_000), // 100bps
+                firstFactor: 10, // 10 bps
+                secondFactor: maxRateLimiterDuration, // 10 slot
+                thirdFactor: referenceAmount, // 1 sol
+                baseFeeMode: 2, // rate limiter mode
+            }
+        );
+        let config = await createConfig(context.banksClient, program, {
+            payer: partner,
+            leftoverReceiver: partner.publicKey,
+            feeClaimer: partner.publicKey,
+            quoteMint,
+            instructionParams,
+        });
+        await mintSplTokenTo(context.banksClient, user, quoteMint, admin, user.publicKey, instructionParams.migrationQuoteThreshold.toNumber());
+
+        // create pool
+        let virtualPool = await createPoolWithSplToken(context.banksClient, program, {
+            poolCreator,
+            payer: operator,
+            quoteMint,
+            config,
+            instructionParams: {
+                name: "test token spl",
+                symbol: "TEST",
+                uri: "abc.com",
+            },
+        });
+        let virtualPoolState = await getVirtualPool(
+            context.banksClient,
+            program,
+            virtualPool
+        );
+
+        // swap with 1 SOL
+        await swap(context.banksClient, program, {
+            config,
+            payer: user,
+            pool: virtualPool,
+            inputTokenMint: quoteMint,
+            outputTokenMint: virtualPoolState.baseMint,
+            amountIn: referenceAmount,
+            minimumAmountOut: new BN(0),
+            referralTokenAccount: null,
+        });
+
+        virtualPoolState = await getVirtualPool(
+            context.banksClient,
+            program,
+            virtualPool
+        );
+
+        let totalTradingFee = virtualPoolState.partnerQuoteFee.add(virtualPoolState.protocolQuoteFee);
+        expect(totalTradingFee.toNumber()).eq(referenceAmount.div(new BN(100)).toNumber());
+
+
+        // swap with 2 SOL
+        await swap(context.banksClient, program, {
+            config,
+            payer: user,
+            pool: virtualPool,
+            inputTokenMint: quoteMint,
+            outputTokenMint: virtualPoolState.baseMint,
+            amountIn: referenceAmount.mul(new BN(2)),
+            minimumAmountOut: new BN(0),
+            referralTokenAccount: null,
+        });
+
+        virtualPoolState = await getVirtualPool(
+            context.banksClient,
+            program,
+            virtualPool
+        );
+
+        let totalTradingFee1 = virtualPoolState.partnerQuoteFee.add(virtualPoolState.protocolQuoteFee);
+        let deltaTradingFee = totalTradingFee1.sub(totalTradingFee);
+        expect(deltaTradingFee.toNumber()).gt(referenceAmount.mul(new BN(2)).div(new BN(100)).toNumber());
+
+        // wait until time pass the 10 slot
+        await warpSlotBy(context, maxRateLimiterDuration.add(new BN(1)));
+
+        // swap with 2 SOL
+        await swap(context.banksClient, program, {
+            config,
+            payer: user,
+            pool: virtualPool,
+            inputTokenMint: quoteMint,
+            outputTokenMint: virtualPoolState.baseMint,
+            amountIn: referenceAmount.mul(new BN(2)),
+            minimumAmountOut: new BN(0),
+            referralTokenAccount: null,
+        });
+
+        virtualPoolState = await getVirtualPool(
+            context.banksClient,
+            program,
+            virtualPool
+        );
+
+        let totalTradingFee2 = virtualPoolState.partnerQuoteFee.add(virtualPoolState.protocolQuoteFee);
+        let deltaTradingFee1 = totalTradingFee2.sub(totalTradingFee1);
+        expect(deltaTradingFee1.toNumber()).eq(referenceAmount.mul(new BN(2)).div(new BN(100)).toNumber());
+    });
+});

--- a/tests/simulate_cu_swap.tests.ts
+++ b/tests/simulate_cu_swap.tests.ts
@@ -48,10 +48,10 @@ describe("Simulate CU swap", () => {
 
       const baseFee: BaseFee = {
         cliffFeeNumerator: new BN(2_500_000),
-        numberOfPeriod: 0,
-        reductionFactor: new BN(0),
-        periodFrequency: new BN(0),
-        feeSchedulerMode: 0,
+        firstFactor: 0,
+        secondFactor: new BN(0),
+        thirdFactor: new BN(0),
+        baseFeeMode: 0,
       };
 
       const instructionParams: ConfigParameters = {

--- a/tests/swap_over_curve.tests.ts
+++ b/tests/swap_over_curve.tests.ts
@@ -1,5 +1,4 @@
-import { BanksClient, ProgramTestContext } from "solana-bankrun";
-import Decimal from "decimal.js";
+import { ProgramTestContext } from "solana-bankrun";
 import {
     createConfig,
     CreateConfigParams,

--- a/tests/utils/common.ts
+++ b/tests/utils/common.ts
@@ -49,7 +49,7 @@ import {
   MAX_SQRT_PRICE,
   MIN_SQRT_PRICE,
 } from "./constants";
-import { BanksClient } from "solana-bankrun";
+import { BanksClient, ProgramTestContext } from "solana-bankrun";
 import { ADMIN_USDC_ATA, LOCAL_ADMIN_KEYPAIR, USDC } from "./bankrun";
 
 export type DynamicVault = IdlAccounts<Vault>["vault"];
@@ -213,6 +213,18 @@ export async function getMint(banksClient: BanksClient, mint: PublicKey) {
 export async function sleep(ms: number) {
   return new Promise((res) => setTimeout(res, ms));
 }
+
+
+export const getCurrentSlot = async (banksClient: BanksClient): Promise<BN> => {
+  let slot = await banksClient.getSlot();
+  return new BN(slot.toString());
+};
+
+export async function warpSlotBy(context: ProgramTestContext, slots: BN) {
+  const clock = await context.banksClient.getClock();
+  await context.warpToSlot(clock.slot + BigInt(slots.toString()));
+}
+
 
 export const SET_COMPUTE_UNIT_LIMIT_IX =
   web3.ComputeBudgetProgram.setComputeUnitLimit({
@@ -382,7 +394,7 @@ export async function createDammV2Config(
   );
   const transaction = await program.methods
     .createConfig(params)
-    .accounts({
+    .accountsPartial({
       config,
       admin: payer.publicKey,
     })

--- a/tests/utils/create_curve.ts
+++ b/tests/utils/create_curve.ts
@@ -1,5 +1,5 @@
 import BN from "bn.js";
-import { ConfigParameters, LiquidityDistributionParameters, LockedVestingParams } from "../instructions";
+import { BaseFee, ConfigParameters, LiquidityDistributionParameters, LockedVestingParams } from "../instructions";
 import Decimal from "decimal.js";
 import { MAX_SQRT_PRICE, MIN_SQRT_PRICE } from "./constants";
 import { assert } from "chai";
@@ -400,6 +400,7 @@ export function designGraphCurve(
     lockedVesting: LockedVestingParams,
     leftOver: number,
     kFactor: number,
+    baseFee: BaseFee
 ): ConfigParameters {
     // 1. finding Pmax and Pmin
     let pMin = getSqrtPriceFromMarketCap(initialMarketCap, totalTokenSupply, tokenBaseDecimal, tokenQuoteDecimal);
@@ -456,9 +457,6 @@ export function designGraphCurve(
     let swapBaseAmountBuffer =
         getSwapAmountWithBuffer(swapBaseAmount, pMin, curve);
 
-    // for (let i = 0; i < 16; i++) {
-    //     console.log("sqrtPrice %d liquidity %d", curve[i].sqrtPrice.toString(), curve[i].liquidity.toString());
-    // }
     let migrationAmount = totalSwapAndMigrationAmount.sub(swapBaseAmountBuffer);
 
     // calculate migration threshold
@@ -484,13 +482,7 @@ export function designGraphCurve(
 
     const instructionParams: ConfigParameters = {
         poolFees: {
-            baseFee: {
-                cliffFeeNumerator: new BN(2_500_000),
-                numberOfPeriod: 0,
-                reductionFactor: new BN(0),
-                periodFrequency: new BN(0),
-                feeSchedulerMode: 0,
-            },
+            baseFee,
             dynamicFee: null,
         },
         activationType: 0,

--- a/tests/utils/create_curve.ts
+++ b/tests/utils/create_curve.ts
@@ -355,10 +355,10 @@ export function designCurve(
         poolFees: {
             baseFee: {
                 cliffFeeNumerator: new BN(2_500_000),
-                numberOfPeriod: 0,
-                reductionFactor: new BN(0),
-                periodFrequency: new BN(0),
-                feeSchedulerMode: 0,
+                firstFactor: 0,
+                secondFactor: new BN(0),
+                thirdFactor: new BN(0),
+                baseFeeMode: 0,
             },
             dynamicFee: null,
         },


### PR DESCRIPTION
- Update max fee to 99%
- Support new base fee mode, called rate limiter. Ex: if user swap 100 SOL, then the first SOL will be charged as 1%, the next SOL will be charged as 5%, ... until it fullfill full input amount