### PR TITLE
refactor: remove damm v2 migration metadata

### DIFF
--- a/programs/dynamic-bonding-curve/src/event.rs
+++ b/programs/dynamic-bonding-curve/src/event.rs
@@ -143,11 +143,6 @@ pub struct EvtCreateMeteoraMigrationMetadata {
 }
 
 #[event]
-pub struct EvtCreateDammV2MigrationMetadata {
-    pub virtual_pool: Pubkey,
-}
-
-#[event]
 pub struct EvtProtocolWithdrawSurplus {
     pub pool: Pubkey,
     pub surplus_amount: u64,

--- a/programs/dynamic-bonding-curve/src/instructions/migration/dynamic_amm_v2/damm_v2_metadata_state.rs
+++ b/programs/dynamic-bonding-curve/src/instructions/migration/dynamic_amm_v2/damm_v2_metadata_state.rs
@@ -1,7 +1,9 @@
+#![allow(deprecated)]
 use anchor_lang::prelude::*;
 use static_assertions::const_assert_eq;
 
 #[account(zero_copy)]
+#[deprecated]
 #[derive(InitSpace, Debug)]
 pub struct MeteoraDammV2Metadata {
     /// pool

--- a/programs/dynamic-bonding-curve/src/instructions/migration/dynamic_amm_v2/migrate_damm_v2_initialize_pool.rs
+++ b/programs/dynamic-bonding-curve/src/instructions/migration/dynamic_amm_v2/migrate_damm_v2_initialize_pool.rs
@@ -30,9 +30,9 @@ pub struct MigrateDammV2Ctx<'info> {
     #[account(mut, has_one = base_vault, has_one = quote_vault, has_one = config)]
     pub virtual_pool: AccountLoader<'info, VirtualPool>,
 
-    /// migration metadata
-    #[account(has_one = virtual_pool)]
-    pub migration_metadata: AccountLoader<'info, MeteoraDammV2Metadata>,
+    /// CHECK: Deprecated. Unused anymore.
+    #[deprecated]
+    pub migration_metadata: UncheckedAccount<'info>,
 
     /// virtual pool config key
     pub config: AccountLoader<'info, PoolConfig>,
@@ -492,8 +492,6 @@ pub fn handle_migrate_damm_v2<'c: 'info, 'info>(
         PoolError::NotPermitToDoThisAction
     );
 
-    let migration_metadata = ctx.accounts.migration_metadata.load()?;
-
     require!(
         virtual_pool.is_curve_complete(config.migration_quote_threshold),
         PoolError::PoolIsIncompleted
@@ -538,7 +536,7 @@ pub fn handle_migrate_damm_v2<'c: 'info, 'info>(
         (
             partner_liquidity_distribution,
             creator_liquidity_distribution,
-            migration_metadata.partner,
+            config.fee_claimer,
             virtual_pool.creator,
         )
     } else {
@@ -546,7 +544,7 @@ pub fn handle_migrate_damm_v2<'c: 'info, 'info>(
             creator_liquidity_distribution,
             partner_liquidity_distribution,
             virtual_pool.creator,
-            migration_metadata.partner,
+            config.fee_claimer,
         )
     };
 

--- a/programs/dynamic-bonding-curve/src/instructions/migration/dynamic_amm_v2/migration_damm_v2_create_metadata.rs
+++ b/programs/dynamic-bonding-curve/src/instructions/migration/dynamic_amm_v2/migration_damm_v2_create_metadata.rs
@@ -1,57 +1,24 @@
+#![allow(deprecated)]
 use anchor_lang::prelude::*;
 
-use crate::constants::seeds::DAMM_V2_METADATA_PREFIX;
-use crate::state::MigrationOption;
-use crate::state::PoolConfig;
-use crate::state::VirtualPool;
-use crate::EvtCreateDammV2MigrationMetadata;
-use crate::PoolError;
-
-use super::MeteoraDammV2Metadata;
-
 #[event_cpi]
+#[deprecated]
 #[derive(Accounts)]
 pub struct MigrationDammV2CreateMetadataCtx<'info> {
-    #[account(has_one=config)]
-    pub virtual_pool: AccountLoader<'info, VirtualPool>,
-
-    pub config: AccountLoader<'info, PoolConfig>,
-
-    #[account(
-        init,
-        payer = payer,
-        seeds = [
-            DAMM_V2_METADATA_PREFIX.as_ref(),
-            virtual_pool.key().as_ref(),
-        ],
-        bump,
-        space = 8 + MeteoraDammV2Metadata::INIT_SPACE
-    )]
-    pub migration_metadata: AccountLoader<'info, MeteoraDammV2Metadata>,
-
-    #[account(mut)]
-    pub payer: Signer<'info>,
-
-    pub system_program: Program<'info, System>,
+    /// CHECK: This is not dangerous because we don't read or write from this account
+    pub virtual_pool: UncheckedAccount<'info>,
+    /// CHECK: This is not dangerous because we don't read or write from this account
+    pub config: UncheckedAccount<'info>,
+    /// CHECK: This is not dangerous because we don't read or write from this account
+    pub migration_metadata: UncheckedAccount<'info>,
+    /// CHECK: This is not dangerous because we don't read or write from this account
+    pub payer: UncheckedAccount<'info>,
+    /// CHECK: This is not dangerous because we don't read or write from this account
+    pub system_program: UncheckedAccount<'info>,
 }
 
 pub fn handle_migration_damm_v2_create_metadata(
-    ctx: Context<MigrationDammV2CreateMetadataCtx>,
+    _ctx: Context<MigrationDammV2CreateMetadataCtx>,
 ) -> Result<()> {
-    let config = ctx.accounts.config.load()?;
-    let migration_option = MigrationOption::try_from(config.migration_option)
-        .map_err(|_| PoolError::InvalidMigrationOption)?;
-    require!(
-        migration_option == MigrationOption::DammV2,
-        PoolError::InvalidMigrationOption
-    );
-    let mut migration_metadata = ctx.accounts.migration_metadata.load_init()?;
-    migration_metadata.virtual_pool = ctx.accounts.virtual_pool.key();
-    migration_metadata.partner = config.fee_claimer;
-
-    emit_cpi!(EvtCreateDammV2MigrationMetadata {
-        virtual_pool: ctx.accounts.virtual_pool.key(),
-    });
-
     Ok(())
 }

--- a/programs/dynamic-bonding-curve/src/lib.rs
+++ b/programs/dynamic-bonding-curve/src/lib.rs
@@ -179,6 +179,10 @@ pub mod dynamic_bonding_curve {
     }
 
     // migrate damm v2
+    #[deprecated(
+        since = "0.1.3",
+        note = "It's unneeded. Will be removed in next release version"
+    )]
     pub fn migration_damm_v2_create_metadata<'c: 'info, 'info>(
         ctx: Context<'_, '_, 'c, 'info, MigrationDammV2CreateMetadataCtx<'info>>,
     ) -> Result<()> {

--- a/programs/dynamic-bonding-curve/src/lib.rs
+++ b/programs/dynamic-bonding-curve/src/lib.rs
@@ -180,7 +180,7 @@ pub mod dynamic_bonding_curve {
 
     // migrate damm v2
     #[deprecated(
-        since = "0.1.3",
+        since = "0.1.7",
         note = "It's unneeded. Will be removed in next release version"
     )]
     pub fn migration_damm_v2_create_metadata<'c: 'info, 'info>(


### PR DESCRIPTION
## Context

- Remove damm v2 migration metadata because it's unnecessary. Will be fully removed in next release version.