### PR TITLE
feat: add EvtCurveProgress

### DIFF
--- a/programs/dynamic-bonding-curve/src/event.rs
+++ b/programs/dynamic-bonding-curve/src/event.rs
@@ -87,6 +87,12 @@ pub struct EvtSwap {
 }
 
 #[event]
+pub struct EvtCurveProgress {
+    pub quote_reserve: u64,
+    pub migration_quote_threshold: u64,
+}
+
+#[event]
 pub struct EvtCurveComplete {
     pub pool: Pubkey,
     pub config: Pubkey,

--- a/programs/dynamic-bonding-curve/src/instructions/ix_swap.rs
+++ b/programs/dynamic-bonding-curve/src/instructions/ix_swap.rs
@@ -1,6 +1,5 @@
 use crate::math::safe_math::SafeMath;
 use crate::state::MigrationProgress;
-use crate::EvtCurveComplete;
 use crate::{
     activation_handler::get_current_point,
     const_pda,
@@ -8,7 +7,7 @@ use crate::{
     state::fee::FeeMode,
     state::{PoolConfig, VirtualPool},
     token::{transfer_from_pool, transfer_from_user},
-    EvtSwap, PoolError,
+    EvtCurveComplete, EvtCurveProgress, EvtSwap, PoolError,
 };
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::instruction::{
@@ -225,6 +224,11 @@ pub fn handle_swap(ctx: Context<SwapCtx>, params: SwapParameters) -> Result<()> 
         has_referral,
         amount_in,
         current_timestamp,
+    });
+
+    emit_cpi!(EvtCurveProgress {
+        quote_reserve: pool.quote_reserve,
+        migration_quote_threshold: config.migration_quote_threshold,
     });
 
     if pool.is_curve_complete(config.migration_quote_threshold) {


### PR DESCRIPTION
# Context
adding a new event to make it trivial for indexers to index bonding curve progress
the current way is not ideal as it requires rpc calls / caching the curve and recreating math from next_sqrt_price to quote_reserve