### PR TITLE
feat: swap event v2

### DIFF
--- a/programs/dynamic-bonding-curve/src/event.rs
+++ b/programs/dynamic-bonding-curve/src/event.rs
@@ -87,6 +87,20 @@ pub struct EvtSwap {
 }
 
 #[event]
+pub struct EvtSwapV2 {
+    pub pool: Pubkey,
+    pub config: Pubkey,
+    pub trade_direction: u8,
+    pub has_referral: bool,
+    pub params: SwapParameters,
+    pub swap_result: SwapResult,
+    pub amount_in: u64,
+    pub current_timestamp: u64,
+    pub quote_reserve: u64,
+    pub migration_quote_threshold: u64,
+}
+
+#[event]
 pub struct EvtCurveComplete {
     pub pool: Pubkey,
     pub config: Pubkey,

--- a/programs/dynamic-bonding-curve/src/state/virtual_pool.rs
+++ b/programs/dynamic-bonding-curve/src/state/virtual_pool.rs
@@ -651,7 +651,7 @@ impl VirtualPool {
 }
 
 /// Encodes all results of swapping
-#[derive(Debug, PartialEq, AnchorDeserialize, AnchorSerialize)]
+#[derive(Debug, PartialEq, AnchorDeserialize, AnchorSerialize, Clone)]
 pub struct SwapResult {
     pub actual_input_amount: u64, // if fees are on input, this can be different that the original input_amount.
     pub output_amount: u64,


### PR DESCRIPTION
# Context
adding a swapv2 event with `quote_reserve` and `migration_quote_threshold` to make it trivial for indexers to index bonding curve progress
the current way is not ideal as it requires rpc calls / caching the curve and recreating math from next_sqrt_price to quote_reserve